### PR TITLE
No need to `into()`

### DIFF
--- a/chapter2/scenario1/http/src/httpresponse.rs
+++ b/chapter2/scenario1/http/src/httpresponse.rs
@@ -11,9 +11,9 @@ pub struct HttpResponse<'a> {
 impl<'a> Default for HttpResponse<'a> {
     fn default() -> Self {
         Self {
-            version: "HTTP/1.1".into(),
-            status_code: "200".into(),
-            status_text: "OK".into(),
+            version: "HTTP/1.1",
+            status_code: "200",
+            status_text: "OK",
             headers: None,
             body: None,
         }
@@ -27,7 +27,7 @@ impl<'a> HttpResponse<'a> {
     ) -> HttpResponse<'a> {
         let mut response: HttpResponse<'a> = HttpResponse::default();
         if status_code != "200" {
-            response.status_code = status_code.into();
+            response.status_code = status_code;
         };
         response.headers = match &headers {
             Some(_h) => headers,
@@ -38,11 +38,11 @@ impl<'a> HttpResponse<'a> {
             }
         };
         response.status_text = match response.status_code {
-            "200" => "OK".into(),
-            "400" => "Bad Request".into(),
-            "404" => "Not Found".into(),
-            "500" => "Internal Server Error".into(),
-            _ => "Not Found".into(),
+            "200" => "OK",
+            "400" => "Bad Request",
+            "404" => "Not Found",
+            "500" => "Internal Server Error",
+            _ => "Not Found",
         };
         response.body = body;
         response


### PR DESCRIPTION
Because most fields of HttpResponse are str, I guess we don't need `into()` in some lines?